### PR TITLE
feat: Only Authenticated session for `/balances` endpoint

### DIFF
--- a/packages/backend/src/features/erc20-token-balances/erc20TokenBalancesController.ts
+++ b/packages/backend/src/features/erc20-token-balances/erc20TokenBalancesController.ts
@@ -7,23 +7,19 @@ import UnauthorizedError from '../../errors/UnauthorizedError'
 
 async function getBalances(request: FastifyRequest, response: FastifyReply) {
   try {
-    const { address, chainId } = request.query as { address: string; chainId: string }
-
     const sessionCookie = request.cookies['session-cookie']
 
-    if (sessionCookie) {
-      const { value: sessionToken, valid } = request.unsignCookie(sessionCookie)
-
-      if (!valid || !sessionToken) {
-        throw new UnauthorizedError('Invalid session', { sessionToken })
-      }
-
-      const balances = await erc20TokenBalancesService.getBalances(address, chainId, sessionToken)
-
-      return response.code(StatusCodes.OK).send(balances)
+    if (!sessionCookie) {
+      throw new UnauthorizedError('Invalid session')
     }
 
-    const balances = await erc20TokenBalancesService.getBalances(address, chainId)
+    const { value: sessionToken, valid } = request.unsignCookie(sessionCookie)
+
+    if (!valid || !sessionToken) {
+      throw new UnauthorizedError('Invalid session', { sessionToken })
+    }
+
+    const balances = await erc20TokenBalancesService.getBalances(sessionToken)
 
     return response.code(StatusCodes.OK).send(balances)
   } catch (error) {

--- a/packages/backend/src/features/erc20-token-balances/erc20TokenBalancesService.ts
+++ b/packages/backend/src/features/erc20-token-balances/erc20TokenBalancesService.ts
@@ -8,22 +8,12 @@ import { getBalancesFromMoralis } from './api-providers/moralis'
 import BadGatewayError from '../../errors/BadGatewayError'
 import UnauthorizedError from '../../errors/UnauthorizedError'
 
-async function getBalances(customAddress?: string, customChainId?: string, sessionToken?: string) {
-  let address, chainId
-
-  if (!customAddress && !sessionToken) {
+async function getBalances(sessionToken?: string) {
+  if (!sessionToken) {
     throw new UnauthorizedError('Invalid session')
   }
 
-  if (sessionToken) {
-    const sessionPayload = authService.verifySession(sessionToken)
-
-    address = sessionPayload.address
-    chainId = sessionPayload.chainId
-  } else {
-    address = customAddress
-    chainId = customChainId
-  }
+  const { address, chainId } = authService.verifySession(sessionToken)
 
   if (!address) {
     throw new BadRequestError('Missing address')


### PR DESCRIPTION
This PR updates the `/balances` endpoint to strictly require a valid authenticated session.  
Previously, users could access it by providing `address` and `chainId` via query parameters, bypassing session validation.

- Removed support for query parameters `address` and `chainId` in `/balances`
- Now the session JWT must be present in the `session-cookie` and will be verified before returning balances
- Adjusted related tests
